### PR TITLE
Issue #74: wrap the FsBinaryFileStream with ZnBufferedReadStream

### DIFF
--- a/src/FileDescriptor/FsBinaryFileStream.class.st
+++ b/src/FileDescriptor/FsBinaryFileStream.class.st
@@ -119,9 +119,24 @@ FsBinaryFileStream >> position [
 ]
 
 { #category : 'positioning' }
-FsBinaryFileStream >> position: aPosition  [
+FsBinaryFileStream >> position: aPosition [ 
 
 	^descriptor position: aPosition 
+]
+
+{ #category : 'reading' }
+FsBinaryFileStream >> readInto: aCollection startingAt: startIndex count: n [
+	"Read n objects into the given collection. 
+	Return number of elements that have been read."
+
+	| max |
+	max := (self size - self position) min: n.
+	aCollection 
+		replaceFrom: startIndex 
+		to: startIndex + max - 1
+		with: (self next: max)
+		startingAt: 1.
+	^ max
 ]
 
 { #category : 'positioning' }

--- a/src/FileSystem-Core/AbstractFileReference.class.st
+++ b/src/FileSystem-Core/AbstractFileReference.class.st
@@ -743,9 +743,8 @@ AbstractFileReference >> readStreamDo: doBlock ifAbsent: absentBlock [
 
 { #category : 'streams' }
 AbstractFileReference >> readStreamEncoded: anEncoding [
-	^ ZnCharacterReadStream
-		on: self binaryReadStream
-		encoding: anEncoding
+	^ self
+		readStreamEncoded: anEncoding
 		stringClass:
 			(String isInUnicodeComparisonMode
 				ifTrue: [ Unicode7 ]
@@ -756,6 +755,26 @@ AbstractFileReference >> readStreamEncoded: anEncoding [
 AbstractFileReference >> readStreamEncoded: anEncoding do: aBlock [
 	| stream |
 	stream := self readStreamEncoded: anEncoding.
+	^ [ aBlock value: stream ] 
+		ensure: [ stream close ]
+]
+
+{ #category : 'streams' }
+AbstractFileReference >> readStreamEncoded: anEncoding stringClass: stringClass [
+	| stream |
+	stream := self fileSystem isDiskFileSystem
+		ifTrue: [ ZnBufferedReadStream on: self binaryReadStream ]
+		ifFalse: [ self binaryReadStream ].
+	^ ZnCharacterReadStream
+		on: stream
+		encoding: anEncoding
+		stringClass: stringClass
+]
+
+{ #category : 'streams' }
+AbstractFileReference >> readStreamEncoded: anEncoding stringClass: stringClass do: aBlock [
+	| stream |
+	stream := self readStreamEncoded: anEncoding stringClass: stringClass.
 	^ [ aBlock value: stream ] 
 		ensure: [ stream close ]
 ]


### PR DESCRIPTION
  without buffer load Rowan in 29459 ms; load GemStone in 48035ms
  with buffer load Rowan in 1691 ms; load GemStone in 2331 ms