### PR TITLE
Adding string to a stream should use different message

### DIFF
--- a/src/FileSystem-Core/FileReference.class.st
+++ b/src/FileSystem-Core/FileReference.class.st
@@ -481,9 +481,9 @@ FileReference >> permissions: permissions [
 FileReference >> printOn: aStream [
 
 	filesystem forReferencePrintOn: aStream.
-	aStream nextPut: ' @ '''.
+	aStream nextPutAll: ' @ '''.
 	filesystem printPath: path on: aStream.
-	aStream nextPut: ''''
+	aStream nextPutAll: ''''
 ]
 
 { #category : 'operations' }

--- a/src/FileSystem-Tests-Core/FileReferenceTest.class.st
+++ b/src/FileSystem-Tests-Core/FileReferenceTest.class.st
@@ -1623,3 +1623,15 @@ FileReferenceTest >> testWriteStreamTruncate [
 		assert: file contents
 		equals: ''
 ]
+
+{ #category : 'tests' }
+FileReferenceTest >> testPrintOn [
+
+| testStream fileRef |
+testStream := PositionableStream on: 'Příliš žluťoučký kůň pěl ďábelské ódy'.
+fileRef := FileReference newTempFilePrefix: 'FileReferencePrintOn' suffix: 'Test'.
+[ self
+	shouldnt: [ fileRef printOn: testStream ]
+	raise: ImproperOperation ]
+ensure: [ fileRef ensureDelete]
+]


### PR DESCRIPTION
The original code used a message which adds a character to the stream.  This can not work correctly as it was a string being actually being added. This patch changes the sent message to a kind that supports adding string to the stream.